### PR TITLE
Claim installation name 'GARLIC'

### DIFF
--- a/plants.txt
+++ b/plants.txt
@@ -31,7 +31,6 @@ eytelia
 fennel
 ferns
 garget
-garlic
 gutweed
 haldi
 hogweed


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1919#azure-dns-operator

* opsctl list installations does not show garlic
* `find . -name "*garlic*"` in MCF and CONFIG and INSTALLATION repos don't show any result

Please title this pull request according to the following format:

    Claim installation name 'NAME'
